### PR TITLE
fix: ignore unavailable playlist entries

### DIFF
--- a/src/stores/video.ts
+++ b/src/stores/video.ts
@@ -1,6 +1,7 @@
 import { defineStore } from "pinia";
 import { invoke } from "@tauri-apps/api/core";
 import { showErrorDialog } from "@/utils/format";
+import { filterPlaylistEntries } from "@/utils/playlist";
 import { useSettingStore } from "@/stores/setting";
 import { useStatusStore } from "@/stores/status";
 import type {
@@ -69,15 +70,17 @@ export const useVideoStore = defineStore("video", () => {
       let isPlaylist = false;
       let playlistEntries: PlaylistEntry[] = [];
 
-      if (info._type === "playlist" && info.entries?.length) {
+      const entries = filterPlaylistEntries(info.entries || []);
+
+      if (info._type === "playlist" && entries.length) {
         isPlaylist = true;
-        playlistEntries = info.entries.map((e, i) => ({
+        playlistEntries = entries.map((e, i) => ({
           id: e.id || String(i + 1),
           title: e.title || `第 ${i + 1} P`,
           duration: e.duration ?? null,
           url: e.url || "",
         }));
-        const firstEntry = info.entries[0];
+        const firstEntry = entries[0];
         const formats: VideoFormat[] = firstEntry?.formats || info.formats || [];
         // 合集字幕：yt-dlp -J 对 playlist 不会在 root 暴露 subtitles，
         // 必须从各 entry 聚合。同语言的 tracks 取首个出现该语言的 entry。
@@ -87,8 +90,8 @@ export const useVideoStore = defineStore("video", () => {
           thumbnail: info.thumbnail || firstEntry?.thumbnail || "",
           duration: info.duration || firstEntry?.duration || 0,
           formats,
-          subtitles: aggregateSubtitleMap(info.entries, "subtitles"),
-          automatic_captions: aggregateSubtitleMap(info.entries, "automatic_captions"),
+          subtitles: aggregateSubtitleMap(entries, "subtitles"),
+          automatic_captions: aggregateSubtitleMap(entries, "automatic_captions"),
         };
       } else {
         videoInfo = info;

--- a/src/utils/playlist.ts
+++ b/src/utils/playlist.ts
@@ -1,0 +1,2 @@
+export const filterPlaylistEntries = <T>(entries: Array<T | null | undefined>): T[] =>
+  entries.filter((entry): entry is T => entry != null);

--- a/tests/playlist.test.ts
+++ b/tests/playlist.test.ts
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { filterPlaylistEntries } from "../src/utils/playlist.ts";
+
+test("filterPlaylistEntries removes unavailable playlist entries", () => {
+  const availableEntry = { id: "video-1", title: "Available video" };
+
+  assert.deepEqual(
+    filterPlaylistEntries([null, availableEntry, undefined]),
+    [availableEntry],
+  );
+});


### PR DESCRIPTION
## Summary

- Ignore unavailable (`null` or `undefined`) playlist entries before YDL GUI reads their metadata.
- Add a regression test for the filtering behavior.

## Root cause

yt-dlp can return unavailable entries in a channel or playlist response. The GUI treated every entry as an object and read `entry.id`, which caused `Cannot read properties of null (reading 'id')`.

## Validation

- `node --test tests/playlist.test.ts`
- `vue-tsc --noEmit`
- `eslint src/` (0 errors; 4 existing warnings)
- `vite build`
